### PR TITLE
08:wipe-app-data

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -5,5 +5,6 @@ export default [
     route("/auth", "routes/auth.tsx"),
     route("/upload","routes/upload.tsx"),
     route("/resume/:id","routes/resume.tsx"),
+    route("/wipe","routes/wipe.tsx"),
 
 ] satisfies RouteConfig;

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -54,7 +54,7 @@ export default function Home() {
           <h1>Monitor Your Job Application Success</h1>
           {!loadingResumes && resumes.length === 0 ? (
             <h2>
-              No Resume Fount.Upload Your Resume First,then get your feedback
+              No Resume Found.Upload Your Resume First,then get your feedback
             </h2>
           ) : (
             <h2>✨ Review Submission & Receive AI-Powered Insights</h2>

--- a/app/routes/wipe.tsx
+++ b/app/routes/wipe.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router";
+import { usePuterStore } from "~/lib/puter";
+
+const WipeApp = () => {
+    const { auth, isLoading, error, clearError, fs, ai, kv } = usePuterStore();
+    const navigate = useNavigate();
+    const [files, setFiles] = useState<FSItem[]>([]);
+
+    const loadFiles = async () => {
+        const files = (await fs.readDir("./")) as FSItem[];
+        setFiles(files);
+    };
+
+    useEffect(() => {
+        loadFiles();
+    }, []);
+
+    useEffect(() => {
+        if (!isLoading && !auth.isAuthenticated) {
+            navigate("/auth?next=/wipe");
+        }
+    }, [isLoading]);
+
+    const handleDelete = async () => {
+        files.forEach(async (file) => {
+            await fs.delete(file.path);
+        });
+        await kv.flush();
+        loadFiles();
+    };
+
+    if (isLoading) {
+        return <div>Loading...</div>;
+    }
+
+    if (error) {
+        return <div>Error {error}</div>;
+    }
+
+    return (
+        <div>
+            Authenticated as: {auth.user?.username}
+            <div>Existing files:</div>
+            <div className="flex flex-col gap-4">
+                {files.map((file) => (
+                    <div key={file.id} className="flex flex-row gap-4">
+                        <p>{file.name}</p>
+                    </div>
+                ))}
+            </div>
+            <div>
+                <button
+                    className="bg-blue-500 text-white px-4 py-2 rounded-md cursor-pointer"
+                    onClick={() => handleDelete()}
+                >
+                    Wipe App Data
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default WipeApp;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Wipe App Data page that lists current stored items and lets authenticated users clear all app data with one action. Unauthenticated users are redirected to sign in. A new navigation route provides access to this page.

- Bug Fixes
  - Corrected the empty-state header on the home page (from “No Resume Fount” to “No Resume Found”) and refined the instruction text for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->